### PR TITLE
Add a 'pip install' wrapper command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a new command, `pip-install-dependency-groups`, which is capable of
+  installing dependency groups by invoking `pip`
+
 ## 0.2.2
 
 - The pre-commit hook sets `pass_filenames: false`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ repos:
       - id: lint-dependency-groups
 ```
 
+### Install CLI
+
+`dependency-groups` includes a `pip` wrapper, `pip-install-dependency-groups`.
+
+Usage is simple, just `pip-install-dependency-groups groupname` to install!
+
+Use `pip-install-dependency-groups --help` for more details.
+
 ## License
 
 `dependency-groups` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,14 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["packaging"]
+dependencies = [
+    "packaging",
+    "tomli;python_version<'3.11'",
+]
 
 [project.scripts]
 lint-dependency-groups = "dependency_groups._lint_dependency_groups:main"
+pip-install-dependency-groups = "dependency_groups._pip_wrapper:main"
 
 [project.urls]
 source = "https://github.com/sirosen/dependency-groups"

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,4 +1,0 @@
-# Requirements Files
-
-These files are shims to bridge the gap between `dependency-groups` and
-consuming tools. `tox r -e render-requirements` produces the content here.

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,0 @@
-twine
-build

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -1,1 +1,0 @@
-coverage[toml]

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,1 +1,0 @@
-pre-commit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,0 @@
-pytest
-coverage[toml]

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -1,2 +1,0 @@
-mypy
-packaging

--- a/src/dependency_groups/_pip_wrapper.py
+++ b/src/dependency_groups/_pip_wrapper.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+from dependency_groups import DependencyGroupResolver
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError:  # pragma: no cover
+        tomllib = None  # type: ignore[assignment]
+
+
+def _invoke_pip(deps: list[str]) -> None:
+    subprocess.check_call([sys.executable, "-m", "pip", "install"] + deps)
+
+
+def main(*, argv: list[str] | None = None) -> None:
+    if not tomllib:
+        print(
+            "Usage error: dependency-groups CLI requires tomli or Python 3.11+",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    parser = argparse.ArgumentParser(description="Install Dependency Groups.")
+    parser.add_argument(
+        "DEPENDENCY_GROUP", nargs="+", help="The dependency groups to install."
+    )
+    parser.add_argument(
+        "-f",
+        "--pyproject-file",
+        default="pyproject.toml",
+        help="The pyproject.toml file. Defaults to trying in the current directory.",
+    )
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    with open(args.pyproject_file, "rb") as fp:
+        pyproject = tomllib.load(fp)
+    dependency_groups_raw = pyproject.get("dependency-groups", {})
+
+    errors: list[str] = []
+    resolved: list[str] = []
+    try:
+        resolver = DependencyGroupResolver(dependency_groups_raw)
+    except (ValueError, TypeError) as e:
+        errors.append(f"{type(e).__name__}: {e}")
+    else:
+        for groupname in args.DEPENDENCY_GROUP:
+            try:
+                resolved.extend(str(r) for r in resolver.resolve(groupname))
+            except (LookupError, ValueError, TypeError) as e:
+                errors.append(f"{type(e).__name__}: {e}")
+
+    if errors:
+        print("errors encountered while examining dependency groups:")
+        for msg in errors:
+            print(f"  {msg}")
+        sys.exit(1)
+
+    _invoke_pip(resolved)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ labels =
 [testenv]
 package = wheel
 wheel_build_env = build_wheel
-deps = -r requirements/test.txt
+commands_pre = pip-install-dependency-groups test
 commands = coverage run -m pytest -v {posargs}
 
 depends =
@@ -21,49 +21,35 @@ depends =
     covreport: covcombine
 
 [testenv:covclean]
-deps = -r requirements/coverage.txt
-skip_install = true
+commands_pre = pip-install-dependency-groups coverage
 commands = coverage erase
 
 [testenv:covcombine]
-deps = -r requirements/coverage.txt
-skip_install = true
+commands_pre = pip-install-dependency-groups coverage
 commands = coverage combine
 
 [testenv:covreport]
-deps = -r requirements/coverage.txt
-skip_install = true
-commands_pre = coverage html --fail-under=0
+commands_pre =
+    pip-install-dependency-groups coverage
+    coverage html --fail-under=0
 commands = coverage report
-
-[testenv:render-requirements]
-deps =
-commands =
-    python -m dependency_groups 'test' -o requirements/test.txt
-    python -m dependency_groups 'coverage' -o requirements/coverage.txt
-    python -m dependency_groups 'lint' -o requirements/lint.txt
-    python -m dependency_groups 'typing' -o requirements/typing.txt
-    python -m dependency_groups 'build' -o requirements/build.txt
 
 
 [testenv:lint]
-deps = -r requirements/lint.txt
-skip_install = true
+commands_pre = pip-install-dependency-groups lint
 commands = pre-commit run -a
+
+[testenv:mypy]
+commands_pre = pip-install-dependency-groups typing
+commands = mypy src/
 
 
 [testenv:twine-check]
 description = "check the metadata on a package build"
-skip_install = true
-deps = -r requirements/build.txt
 allowlist_externals = rm
-commands_pre = rm -rf dist/
+commands_pre =
+    pip-install-dependency-groups build
+    rm -rf dist/
 # check that twine validating package data works
 commands = python -m build
            twine check dist/*
-
-
-[testenv:mypy]
-deps = -r requirements/typing.txt
-skip_install = true
-commands = mypy src/


### PR DESCRIPTION
pip-install-dependency-groups installs dependency groups by calling
`pip` in a subprocess.

Use this to replace the rendered requirements data in `requirements/`
by having `tox` invoke `pip-install-dependency-groups` as a
pre-command.
