### PR TITLE
Add support for 3.8 and update the way CI runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py: ['3.9', '3.10', '3.11', '3.12', '3.13']
-    name: "Run tests on ${{ matrix.os }}, py${{ matrix.py }}"
+    name: "Run tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +49,13 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: ${{ matrix.py }}
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "dependency-groups"
 version = "1.0.0"
 description = 'A tool for resolving PEP 735 Dependency Group data'
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = { text = "MIT" }
 keywords = []
 authors = [
@@ -24,10 +24,12 @@ authors = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/dependency_groups/_implementation.py
+++ b/src/dependency_groups/_implementation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import re
 import typing as t

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ env_list =
     lint
     mypy
     covclean
-    py{39,310,311,312,313}
+    py{38,39,310,311,312,313}
     covcombine
     covreport
 labels =
-    ci = py, covcombine, covreport
+    ci = py{38,39,310,311,312,313}, covcombine, covreport
 
 [testenv]
 package = wheel
@@ -16,8 +16,8 @@ commands_pre = pip-install-dependency-groups test
 commands = coverage run -m pytest -v {posargs}
 
 depends =
-    py{39,310,311,312},py: clean
-    covcombine: py,py{39,310,311,312}
+    py{38,39,310,311,312},py: clean
+    covcombine: py,py{38,39,310,311,312}
     covreport: covcombine
 
 [testenv:covclean]


### PR DESCRIPTION
Also add 3.13 to the classifiers.


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--4.org.readthedocs.build/en/4/

<!-- readthedocs-preview dependency-groups end -->