### PR TITLE
chore: allow uv to run the tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ docs = ["sphinx>=8.1", "sphinx-issues>=5", "furo"]
 lint = ["pre-commit"]
 typing = ["mypy", "packaging"]
 build = ["twine", "build"]
-dev = [{include-group = "coverage"}, {include-group = "test"}]
+dev = [{include-group = "test"}]
 
 [project]
 name = "dependency-groups"
 version = "1.1.0"
 description = 'A tool for resolving PEP 735 Dependency Group data'
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = { text = "MIT" }
 keywords = []
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,14 @@ docs = ["sphinx>=8.1", "sphinx-issues>=5", "furo"]
 lint = ["pre-commit"]
 typing = ["mypy", "packaging"]
 build = ["twine", "build"]
+dev = [{include-group = "coverage"}, {include-group = "test"}]
 
 [project]
 name = "dependency-groups"
 version = "1.1.0"
 description = 'A tool for resolving PEP 735 Dependency Group data'
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 keywords = []
 authors = [
@@ -49,6 +50,11 @@ documentation = "https://dependency-groups.readthedocs.io/"
 
 [tool.setuptools.package-data]
 dependency_groups = ["py.typed"]
+
+[tool.uv]
+environments = [
+  "python_version >= '3.10'",
+]
 
 
 [tool.coverage.run]


### PR DESCRIPTION
This allows `uv run pytest` to work, which is nice because due to the usage of dependency-groups to install the test dependences, if it's broken, it breaks instantly and doesn't produce the pytest output when running `tox -e ...`.


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--6.org.readthedocs.build/en/6/

<!-- readthedocs-preview dependency-groups end -->