### PR TITLE
feat: allow multiple groups

### DIFF
--- a/src/dependency_groups/_implementation.py
+++ b/src/dependency_groups/_implementation.py
@@ -195,14 +195,14 @@ class DependencyGroupResolver:
 
 
 def resolve(
-    dependency_groups: Mapping[str, t.Union[str, Mapping[str, str]]], group: str, /
+    dependency_groups: Mapping[str, t.Union[str, Mapping[str, str]]], /, *groups: str
 ) -> tuple[str, ...]:
     """
     Resolve a dependency group to a tuple of requirements, as strings.
 
     :param dependency_groups: the parsed contents of the ``[dependency-groups]`` table
         from ``pyproject.toml``
-    :param group: the name of the group to resolve
+    :param groups: the name of the group(s) to resolve
 
     :raises TypeError: if the inputs appear to be the wrong types
     :raises ValueError: if the data does not appear to be valid dependency group data
@@ -210,5 +210,7 @@ def resolve(
     :raises packaging.requirements.InvalidRequirement: if a specifier is not valid
     """
     return tuple(
-        str(r) for r in DependencyGroupResolver(dependency_groups).resolve(group)
+        str(r)
+        for group in groups
+        for r in DependencyGroupResolver(dependency_groups).resolve(group)
     )

--- a/tests/test_resolve_func.py
+++ b/tests/test_resolve_func.py
@@ -24,6 +24,16 @@ def test_single_include_group():
     assert set(resolve(groups, "test")) == {"pytest", "sqlalchemy"}
 
 
+def test_sdual_include_group():
+    groups = {
+        "test": [
+            "pytest",
+        ],
+        "runtime": ["sqlalchemy"],
+    }
+    assert set(resolve(groups, "test", "runtime")) == {"pytest", "sqlalchemy"}
+
+
 def test_normalized_group_name():
     groups = {
         "TEST": ["pytest"],


### PR DESCRIPTION
In most cases when using this, multiple groups are allowed, so this seems like a natural extension of the API. Due to the positional only args, it's completely backward compatible.


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--7.org.readthedocs.build/en/7/

<!-- readthedocs-preview dependency-groups end -->