### PR TITLE
chore: use flit-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,12 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+  - repo: https://github.com/henryiii/check-sdist
+    rev: v1.2.0
+    hooks:
+      - id: check-sdist
+        args: [--inject-junk]
+        additional_dependencies: ["flit-core"]
   - repo: "local"
     hooks:
       # When Dependabot submits a PR to update a workflow,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["flit-core"]
+build-backend = "flit_core.buildapi"
 
 [dependency-groups]
 coverage = ["coverage[toml]"]
@@ -48,8 +48,10 @@ source = "https://github.com/sirosen/dependency-groups"
 changelog = "https://github.com/sirosen/dependency-groups/blob/main/CHANGELOG.rst"
 documentation = "https://dependency-groups.readthedocs.io/"
 
-[tool.setuptools.package-data]
-dependency_groups = ["py.typed"]
+
+[tool.flit.sdist]
+include = ["LICENSE.txt", "CHANGELOG.rst", "tests/*.py", "tox.ini"]
+
 
 [tool.uv]
 environments = [
@@ -91,3 +93,6 @@ files = ["src"]
 [tool.isort]
 profile = "black"
 known_first_party = ["mddj"]
+
+[tool.check-sdist]
+git-only = [".*", "Makefile", "docs/*", "scripts/*"]


### PR DESCRIPTION
Switching to flit-core. Added check-sdist since it's easy to miss things with flit-core. Not sure exactly what you want in the SDist; I can put everything in or go minimal. Sort of went half-and-half. Maybe the tox.ini there doesn't make sense, actually.

----

```console
$ uv build                       # Takes 526ms
$ tar -tf dist/*.tar.gz
dependency_groups-1.1.0/CHANGELOG.rst
dependency_groups-1.1.0/LICENSE.txt
dependency_groups-1.1.0/README.rst
dependency_groups-1.1.0/pyproject.toml
dependency_groups-1.1.0/src/dependency_groups/__init__.py
dependency_groups-1.1.0/src/dependency_groups/__main__.py
dependency_groups-1.1.0/src/dependency_groups/_implementation.py
dependency_groups-1.1.0/src/dependency_groups/_lint_dependency_groups.py
dependency_groups-1.1.0/src/dependency_groups/_pip_wrapper.py
dependency_groups-1.1.0/src/dependency_groups/py.typed
dependency_groups-1.1.0/tests/test_lint_cli.py
dependency_groups-1.1.0/tests/test_resolve_func.py
dependency_groups-1.1.0/tests/test_resolver_class.py
dependency_groups-1.1.0/tox.ini
dependency_groups-1.1.0/PKG-INFO
$ unzip -l dist/*.whl
Archive:  dist/dependency_groups-1.1.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      250  10-29-2024 10:50   dependency_groups/__init__.py
     1293  10-29-2024 10:50   dependency_groups/__main__.py
     8100  10-29-2024 10:50   dependency_groups/_implementation.py
     1894  10-29-2024 10:50   dependency_groups/_lint_dependency_groups.py
     2049  10-29-2024 10:50   dependency_groups/_pip_wrapper.py
        0  10-29-2024 10:50   dependency_groups/py.typed
      155  01-01-2016 00:00   dependency_groups-1.1.0.dist-info/entry_points.txt
     1099  10-29-2024 10:50   dependency_groups-1.1.0.dist-info/LICENSE.txt
       81  01-01-2016 00:00   dependency_groups-1.1.0.dist-info/WHEEL
     2137  01-01-2016 00:00   dependency_groups-1.1.0.dist-info/METADATA
      979  01-01-2016 00:00   dependency_groups-1.1.0.dist-info/RECORD
---------                     -------
    18037                     11 files
```


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--9.org.readthedocs.build/en/9/

<!-- readthedocs-preview dependency-groups end -->