### PR TITLE
Update to allow use with `tox-uv`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,12 @@ env_list =
     covreport
 labels =
     ci = py{38,39,310,311,312,313}, covcombine, covreport
+minversion = 4.22.0
 
 [testenv]
 package = wheel
 wheel_build_env = build_wheel
-commands_pre = pip-install-dependency-groups test
+dependency_groups = test
 commands = coverage run -m pytest -v {posargs}
 
 depends =
@@ -21,35 +22,36 @@ depends =
     covreport: covcombine
 
 [testenv:covclean]
-commands_pre = pip-install-dependency-groups coverage
+skip_install = true
+dependency_groups = coverage
 commands = coverage erase
 
 [testenv:covcombine]
-commands_pre = pip-install-dependency-groups coverage
+skip_install = true
+dependency_groups = coverage
 commands = coverage combine
 
 [testenv:covreport]
-commands_pre =
-    pip-install-dependency-groups coverage
-    coverage html --fail-under=0
+skip_install = true
+dependency_groups = coverage
+commands_pre = coverage html --fail-under=0
 commands = coverage report
 
 
 [testenv:lint]
-commands_pre = pip-install-dependency-groups lint
+dependency_groups = lint
 commands = pre-commit run -a
 
 [testenv:mypy]
-commands_pre = pip-install-dependency-groups typing
+dependency_groups = typing
 commands = mypy src/
 
 
 [testenv:twine-check]
 description = "check the metadata on a package build"
 allowlist_externals = rm
-commands_pre =
-    pip-install-dependency-groups build
-    rm -rf dist/
+dependency_groups = build
+commands_pre = rm -rf dist/
 # check that twine validating package data works
 commands = python -m build
            twine check dist/*
@@ -58,10 +60,9 @@ commands = python -m build
 [testenv:docs]
 description = "build docs with sphinx"
 basepython = python3.12
+dependency_groups = docs
 allowlist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
-commands_pre =
-    pip-install-dependency-groups -f {toxinidir}/pyproject.toml docs
-    rm -rf _build/
+commands_pre = rm -rf _build/
 commands = sphinx-build -d _build/doctrees -b dirhtml -W . _build/dirhtml {posargs}


### PR DESCRIPTION
Some issues were raised when putting the repo through a trial run of `tox` with `tox-uv` installed.

"pip" is not included in package dependencies, but the pip wrapper, `pip-install-dependency-groups` uses it.

To resolve, `tox.ini` is updated to use the new `dependency_groups` support from v4.22.0+

EDIT: this no longer adds `pip` to the `test` deps.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--11.org.readthedocs.build/en/11/

<!-- readthedocs-preview dependency-groups end -->