### PR TITLE
feat: script improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
 [project.scripts]
 lint-dependency-groups = "dependency_groups._lint_dependency_groups:main"
 pip-install-dependency-groups = "dependency_groups._pip_wrapper:main"
+dependency-groups = "dependency_groups.__main__:main"
+
+[project.optional-dependencies]
+cli = ["tomli; python_version<'3.11'"]
 
 [project.urls]
 source = "https://github.com/sirosen/dependency-groups"

--- a/src/dependency_groups/__main__.py
+++ b/src/dependency_groups/__main__.py
@@ -9,43 +9,62 @@ try:
 except ImportError:
     try:
         import tomli as tomllib  # type: ignore[no-redef]
-    except ImportError:
-        tomllib = None  # type: ignore[assignment]
+    except ModuleNotFoundError:
+        print(
+            "Usage error: dependency-groups CLI requires tomli or Python 3.11+",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
 
-if not tomllib:
-    print(
-        "Usage error: dependency-groups CLI requires tomli or Python 3.11+",
-        file=sys.stderr,
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "A dependency-groups CLI. Prints out a resolved group, newline-delimited."
+        )
     )
-    sys.exit(2)
-
-parser = argparse.ArgumentParser(
-    description=(
-        "A dependency-groups CLI. Prints out a resolved group, newline-delimited."
+    parser.add_argument(
+        "GROUP_NAME", nargs="*", help="The dependency group(s) to resolve."
     )
-)
-parser.add_argument("GROUP_NAME", help="The dependency group to resolve.")
-parser.add_argument(
-    "-f",
-    "--pyproject-file",
-    default="pyproject.toml",
-    help="The pyproject.toml file. Defaults to trying in the current directory.",
-)
-parser.add_argument(
-    "-o",
-    "--output",
-    help="An output file. Defaults to stdout.",
-)
-args = parser.parse_args()
+    parser.add_argument(
+        "-f",
+        "--pyproject-file",
+        default="pyproject.toml",
+        help="The pyproject.toml file. Defaults to trying in the current directory.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="An output file. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "-l",
+        "--list",
+        action="store_true",
+        help="List the available dependency groups",
+    )
+    args = parser.parse_args()
 
-with open(args.pyproject_file, "rb") as fp:
-    pyproject = tomllib.load(fp)
+    with open(args.pyproject_file, "rb") as fp:
+        pyproject = tomllib.load(fp)
 
-dependency_groups_raw = pyproject.get("dependency-groups", {})
-content = "\n".join(resolve(dependency_groups_raw, args.GROUP_NAME))
+    dependency_groups_raw = pyproject.get("dependency-groups", {})
 
-if args.output is None or args.output == "-":
-    print(content)
-else:
-    with open(args.output, "w") as fp:
-        print(content, file=fp)
+    if args.list:
+        print(*dependency_groups_raw.keys())
+        return
+    if not args.GROUP_NAME:
+        print("A GROUP_NAME is required", file=sys.stderr)
+        raise SystemExit(3)
+
+    content = "\n".join(resolve(dependency_groups_raw, *args.GROUP_NAME))
+
+    if args.output is None or args.output == "-":
+        print(content)
+    else:
+        with open(args.output, "w") as fp:
+            print(content, file=fp)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This makes several improvements to the `python -m dependency-groups` script:

* Adds a `dependency-groups` script, so that `uvx dependency-groups` and `pipx run dependency-groups` works, along with `pipx install`/`uv tool install`.
* Adds a `cli` extra so that `pipx run dependency-groups[cli]` works on Python < 3.11
* Allows more than one extra to be requested
* Adds a `--list` to quickly see all the dependency groups available


I don't think there are CLI tests yet, so didn't add tests.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--13.org.readthedocs.build/en/13/

<!-- readthedocs-preview dependency-groups end -->