### PR TITLE
Use only one resolver in functional API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Optimize the behavior of the ``resolve()`` function on multiple groups.
+
 1.3.0
 -----
 

--- a/src/dependency_groups/_implementation.py
+++ b/src/dependency_groups/_implementation.py
@@ -206,8 +206,5 @@ def resolve(
     :raises LookupError: if group name is absent
     :raises packaging.requirements.InvalidRequirement: if a specifier is not valid
     """
-    return tuple(
-        str(r)
-        for group in groups
-        for r in DependencyGroupResolver(dependency_groups).resolve(group)
-    )
+    resolver = DependencyGroupResolver(dependency_groups)
+    return tuple(str(r) for group in groups for r in resolver.resolve(group))


### PR DESCRIPTION
This is a small optimization. Rather than a resolver per group, there
is only one resolver. As a result, resolutions done on one group are
stored on the instance and available to subsequent resolution calls.

More trivially, we save on some object instantiation overheads.


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--15.org.readthedocs.build/en/15/

<!-- readthedocs-preview dependency-groups end -->