### PR TITLE
Convert license metadata to the PEP 639 format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit-core"]
+requires = ["flit-core>=3.11"]
 build-backend = "flit_core.buildapi"
 
 [dependency-groups]
@@ -17,7 +17,8 @@ version = "1.3.0"
 description = 'A tool for resolving PEP 735 Dependency Group data'
 readme = "README.rst"
 requires-python = ">=3.8"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE.txt"]
 keywords = []
 authors = [
   { name = "Stephen Rosen", email = "sirosen0@gmail.com" },


### PR DESCRIPTION
The table form of `project.license` has been deprecated.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--23.org.readthedocs.build/en/23/

<!-- readthedocs-preview dependency-groups end -->