### PR TITLE
Update outdated GitHub links

### DIFF
--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -47,7 +47,7 @@ The ``lint-dependency-groups`` CLI is also available as a pre-commit hook:
 .. code-block:: yaml
 
     repos:
-      - repo: https://github.com/sirosen/dependency-groups
+      - repo: https://github.com/pypa/dependency-groups
         rev: 1.3.0
         hooks:
           - id: lint-dependency-groups

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
-issues_github_path = "sirosen/dependency-groups"
+issues_github_path = "pypa/dependency-groups"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -31,7 +31,7 @@ html_theme = "furo"
 pygments_style = "friendly"
 pygments_dark_style = "monokai"  # this is a furo-specific option
 html_theme_options = {
-    "source_repository": "https://github.com/sirosen/dependency-groups/",
+    "source_repository": "https://github.com/pypa/dependency-groups/",
     "source_branch": "main",
     "source_directory": "docs/",
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,9 @@ Dependency Groups
 An implementation of Dependency Groups (`PEP 735 <https://peps.python.org/pep-0735/>`_).
 
 The source code is hosted in `a GitHub repo
-<https://github.com/sirosen/dependency-groups/>`_, and bugs and
+<https://github.com/pypa/dependency-groups/>`_, and bugs and
 features are tracked in the associated `issue tracker
-<https://github.com/sirosen/dependency-groups/issues/>`_.
+<https://github.com/pypa/dependency-groups/issues/>`_.
 
 .. toctree::
     :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ dependency-groups = "dependency_groups.__main__:main"
 cli = ["tomli; python_version<'3.11'"]
 
 [project.urls]
-source = "https://github.com/sirosen/dependency-groups"
-changelog = "https://github.com/sirosen/dependency-groups/blob/main/CHANGELOG.rst"
+source = "https://github.com/pypa/dependency-groups"
+changelog = "https://github.com/pypa/dependency-groups/blob/main/CHANGELOG.rst"
 documentation = "https://dependency-groups.readthedocs.io/"
 
 


### PR DESCRIPTION
This repository was moved into the PyPA organization, so update the links accordingly.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--24.org.readthedocs.build/en/24/

<!-- readthedocs-preview dependency-groups end -->