### PR TITLE
Fix name normalization bug

### DIFF
--- a/src/dependency_groups/_implementation.py
+++ b/src/dependency_groups/_implementation.py
@@ -12,7 +12,7 @@ def _normalize_name(name: str) -> str:
 
 
 def _normalize_group_names(
-    dependency_groups: Mapping[str, str | Mapping[str, str]]
+    dependency_groups: Mapping[str, str | Mapping[str, str]],
 ) -> Mapping[str, str | Mapping[str, str]]:
     original_names: dict[str, list[str]] = {}
     normalized_groups = {}
@@ -171,17 +171,16 @@ class DependencyGroupResolver:
             if isinstance(item, Requirement):
                 resolved_group.append(item)
             elif isinstance(item, DependencyGroupInclude):
-                if item.include_group in self._include_graph_ancestors.get(group, ()):
+                include_group = _normalize_name(item.include_group)
+                if include_group in self._include_graph_ancestors.get(group, ()):
                     raise CyclicDependencyError(
                         requested_group, group, item.include_group
                     )
-                self._include_graph_ancestors[item.include_group] = (
+                self._include_graph_ancestors[include_group] = (
                     *self._include_graph_ancestors.get(group, ()),
                     group,
                 )
-                resolved_group.extend(
-                    self._resolve(item.include_group, requested_group)
-                )
+                resolved_group.extend(self._resolve(include_group, requested_group))
             else:  # unreachable
                 raise NotImplementedError(
                     f"Invalid dependency group item after parse: {item}"

--- a/tests/test_resolver_class.py
+++ b/tests/test_resolver_class.py
@@ -127,3 +127,21 @@ def test_no_double_parse():
         assert len(deceived_parse) == 1
         assert isinstance(deceived_parse[0], DependencyGroupInclude)
         assert deceived_parse[0].include_group == "perfidy"
+
+
+@pytest.mark.parametrize("group_name_declared", ("foo-bar", "foo_bar", "foo..bar"))
+@pytest.mark.parametrize("group_name_used", ("foo-bar", "foo_bar", "foo..bar"))
+def test_normalized_name_is_used_for_include_group_lookups(
+    group_name_declared, group_name_used
+):
+    groups = {
+        group_name_declared: ["spam"],
+        "eggs": [{"include-group": group_name_used}],
+    }
+    resolver = DependencyGroupResolver(groups)
+
+    result = resolver.resolve("eggs")
+    assert len(result) == 1
+    assert isinstance(result[0], Requirement)
+    req = result[0]
+    assert req.name == "spam"


### PR DESCRIPTION
Group names were not being normalized when loaded from includes. As a result, they didn't match the normalized names used for the loaded groups.

This updates the internal name usage to be normalized during resolution. Errors will still contain the non-normalized name which the user used if possible (see: the `CyclicDependencyError` parameters).

A new test confirms the fix, and fails without it.

Initially reported via `pip` v25.1 in https://github.com/pypa/pip/issues/13372
cc @henryiii , I intend to merge this and cut a release to fix pretty quickly, assuming CI passes.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--26.org.readthedocs.build/en/26/

<!-- readthedocs-preview dependency-groups end -->