### PR TITLE
feat: test on and support Python 3.14's color --help

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
+          allow-prereleases: true
           python-version: |
             3.8
             3.9
@@ -24,6 +25,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
 
       # get the week of the year (1-52) for cache control
       # this ensures that at least weekly we'll test with a clear cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/dependency_groups/__main__.py
+++ b/src/dependency_groups/__main__.py
@@ -1,6 +1,6 @@
-import argparse
 import sys
 
+from ._argparse_compat import ArgumentParser
 from ._implementation import resolve
 from ._toml_compat import tomllib
 
@@ -13,7 +13,7 @@ def main() -> None:
         )
         raise SystemExit(2)
 
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description=(
             "A dependency-groups CLI. Prints out a resolved group, newline-delimited."
         )

--- a/src/dependency_groups/_argparse_compat.py
+++ b/src/dependency_groups/_argparse_compat.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+import functools
+import sys
+
+__all__ = ["ArgumentParser"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+ArgumentParser = functools.partial(argparse.ArgumentParser)
+
+if sys.version_info >= (3, 14):
+    ArgumentParser = functools.partial(
+        ArgumentParser, color=True, suggest_on_error=True
+    )

--- a/src/dependency_groups/_lint_dependency_groups.py
+++ b/src/dependency_groups/_lint_dependency_groups.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import argparse
 import sys
 
+from ._argparse_compat import ArgumentParser
 from ._implementation import DependencyGroupResolver
 from ._toml_compat import tomllib
 
@@ -15,7 +15,7 @@ def main(*, argv: list[str] | None = None) -> None:
         )
         raise SystemExit(2)
 
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description=(
             "Lint Dependency Groups for validity. "
             "This will eagerly load and check all of your Dependency Groups."

--- a/src/dependency_groups/_pip_wrapper.py
+++ b/src/dependency_groups/_pip_wrapper.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import argparse
 import subprocess
 import sys
 
+from ._argparse_compat import ArgumentParser
 from ._implementation import DependencyGroupResolver
 from ._toml_compat import tomllib
 
@@ -20,7 +20,7 @@ def main(*, argv: list[str] | None = None) -> None:
         )
         raise SystemExit(2)
 
-    parser = argparse.ArgumentParser(description="Install Dependency Groups.")
+    parser = ArgumentParser(description="Install Dependency Groups.")
     parser.add_argument(
         "DEPENDENCY_GROUP", nargs="+", help="The dependency groups to install."
     )

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ env_list =
     lint
     mypy
     covclean
-    py{38,39,310,311,312,313}
+    py{38,39,310,311,312,313,314}
     covcombine
     covreport
 labels =
-    ci = py{38,39,310,311,312,313}, covcombine, covreport
+    ci = py{38,39,310,311,312,313,314}, covcombine, covreport
     ci-mypy = mypy-py38, mypy-py313
     ci-package-check = twine-check
 minversion = 4.22.0
@@ -19,8 +19,8 @@ dependency_groups = test
 commands = coverage run -m pytest -v {posargs}
 
 depends =
-    py{38,39,310,311,312},py: clean
-    covcombine: py,py{38,39,310,311,312}
+    py{38,39,310,311,312,313,314},py: clean
+    covcombine: py,py{38,39,310,311,312,313,314}
     covreport: covcombine
 
 [testenv:covclean]


### PR DESCRIPTION
I also like to add `allow_abbrev=False`, which works on 3.8+.

We could drop 3.8 now.

<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--27.org.readthedocs.build/en/27/

<!-- readthedocs-preview dependency-groups end -->