### PR TITLE
Remove support for 3.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,6 @@ jobs:
         with:
           allow-prereleases: true
           python-version: |
-            3.8
             3.9
             3.10
             3.11
@@ -47,7 +46,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - pythons: ["3.8", "3.13"]
+          - pythons: ["3.9", "3.13"]
             tox_label: "ci-mypy"
           - pythons: ["3.13"]
             tox_label: "ci-package-check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 Unreleased
 ----------
 
+- Add support for Python 3.14
+- Remove support for Python 3.8
+
 1.3.1
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ description = "Combine coverage outputs"
 skip_install = true
 dependency_groups = ["coverage"]
 commands = [["coverage", "combine"]]
-depends = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+depends = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.tox.env.covreport]
 description = "Report on combined coverage outputs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ name = "dependency-groups"
 version = "1.3.1"
 description = 'A tool for resolving PEP 735 Dependency Group data'
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE.txt"]
 keywords = []
@@ -26,7 +26,6 @@ authors = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -112,7 +111,6 @@ env_list = [
     "covclean",
     "covcombine",
     "covreport",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",
@@ -122,8 +120,8 @@ env_list = [
 ]
 
 [tool.tox.labels]
-ci = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "covcombine", "covreport"]
-ci-mypy = ["mypy-py38", "mypy-py313"]
+ci = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "covcombine", "covreport"]
+ci-mypy = ["mypy-py39", "mypy-py313"]
 ci-package-check = ["twine-check"]
 
 [tool.tox.env_run_base]
@@ -145,7 +143,7 @@ description = "Combine coverage outputs"
 skip_install = true
 dependency_groups = ["coverage"]
 commands = [["coverage", "combine"]]
-depends = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+depends = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.tox.env.covreport]
 description = "Report on combined coverage outputs"
@@ -168,7 +166,7 @@ dependency_groups = ["typing"]
 commands = [["mypy", "src/", {replace = "posargs", extend = true} ]]
 depends = []
 
-[tool.tox.env.mypy-py38]
+[tool.tox.env.mypy-py39]
 base = ["tool.tox.env.mypy"]
 
 [tool.tox.env.mypy-py313]


### PR DESCRIPTION
Also add a changelog note for 3.14 to go with this.


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--28.org.readthedocs.build/en/28/

<!-- readthedocs-preview dependency-groups end -->