### PR TITLE
chore: migrate from flake8/isort/black/pyupgrade to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = .git,.tox,__pycache__,.eggs,dist,.venv*
-max-line-length = 88
-extend-ignore = W503,W504,E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
     rev: 0.31.0
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-typing-as-t]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.14
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,6 @@ repos:
     rev: 0.31.0
     hooks:
       - id: check-github-workflows
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
-        args: ["--py39-plus"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,9 @@ repos:
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.15.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/sirosen/slyp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,22 +20,12 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
     hooks:
-      - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - 'flake8-bugbear==24.12.12'
-          - 'flake8-comprehensions==3.16.0'
-          - 'flake8-typing-as-t==1.0.0'
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/sirosen/slyp
     rev: 0.8.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,16 @@ ignore_missing_imports = true
 disallow_subclassing_any = false
 files = ["src"]
 
-[tool.isort]
-profile = "black"
-known_first_party = ["mddj"]
+[tool.ruff]
+line-length = 88
+src = ["src"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "B", "C4", "I", "TCH"]
+ignore = ["E203"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["dependency_groups"]
 
 [tool.check-sdist]
 git-only = [".*", "Makefile", "docs/*", "scripts/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,10 @@ files = ["src"]
 [tool.ruff]
 line-length = 88
 src = ["src"]
+target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "B", "C4", "I", "TCH"]
+select = ["E4", "E7", "E9", "F", "B", "C4", "I", "TCH", "UP"]
 ignore = ["E203"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,7 @@ files = ["src"]
 
 [tool.ruff]
 line-length = 88
-src = ["src"]
-target-version = "py39"
+show-fixes = true
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "B", "C4", "I", "TCH", "UP"]

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -37,7 +37,7 @@ Unreleased
 ----------
 
 {new_version}
-{'-' * len(new_version)}
+{"-" * len(new_version)}
 
 """,
         content,


### PR DESCRIPTION
First step, minimal old-tools -> ruff conversion, without adding/changing anything. See #8. I can now run pre-commit locally again. pyupgrade was broken before for me.

Also did pyupgrade, and some hand updates/cleanup (newer ruff follows newer black, this was using black 24, only one small change though).

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Replace flake8 (with bugbear, comprehensions, typing-as-t plugins), isort, and black pre-commit hooks with ruff lint and format hooks.

### Changes

- **Remove `.flake8`** config file
- **Replace `[tool.isort]`** with `[tool.ruff]` config in `pyproject.toml`
- **Map flake8 plugin rules** to ruff `select` categories: `B` (bugbear), `C4` (comprehensions), `I` (isort), `TCH` (typing-as-t)
- **Ignore `E203`** for ruff-format compat (previously `extend-ignore`)
- **Fix `known-first-party`** from stale `"mddj"` to `"dependency_groups"`

Assisted-by: OpenCode:glm-5.1


<!-- readthedocs-preview dependency-groups start -->
----
📚 Documentation preview 📚: https://dependency-groups--38.org.readthedocs.build/en/38/

<!-- readthedocs-preview dependency-groups end -->